### PR TITLE
Update specs and add support for FlaggedStorage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
 - nightly
 - beta
 - stable
-- 1.24.0
+- 1.29.0
 
 cache:
   cargo: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,5 @@ travis-ci = { repository = "torkleyy/specs-static" }
 derivative = "1"
 hibitset = "0.5"
 shred = "0.7"
-specs = "0.11"
+specs = "0.14"
+shrev = "1.0"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please see [the basic example](examples/basic.rs).
 
 ### Required Rust version
 
-`1.24 stable`
+`1.29 stable`
 
 ## Features
 


### PR DESCRIPTION
Updated to latest specs, adds shrev. This commit includes adding FlaggedStorage support underneath specs-static. This is useful for caching tile coordinates and then rendering them in a pass seperately, only updating the cache on changes. This requires importing shrev for the EventChannel as its not exported from specs